### PR TITLE
bcAsyncInput directive improvements

### DIFF
--- a/app/partials/security-center.jade
+++ b/app/partials/security-center.jade
@@ -73,7 +73,7 @@
 
       .flex-center(ng-show="display.action == 'email' && display.editingEmail")       
         p(translate="YOUR_EMAIL_ADDRESS")
-        bc-async-input(inline security-center type="email" ng-required="true" placeholder="'EMAIL_ADDRESS' | translate", ng-model="user.email", on-save="changeEmail", action-title="'CHANGE_EMAIL_ADDRESS' | translate", autofocus)
+        bc-async-input.width-100.pll(inline security-center type="email" ng-required="true" placeholder="'EMAIL_ADDRESS' | translate", ng-model="user.email", on-save="changeEmail", action-title="'CHANGE_EMAIL_ADDRESS' | translate", autofocus)
       .flex-center(ng-show="display.action == 'securityphrase'")        
         p.flex-1.prl(translate="RECOVERY_PHRASE_SECURITY_CENTER")
         .flex-1.mll.backup-phrase-actions

--- a/app/partials/security-center.jade
+++ b/app/partials/security-center.jade
@@ -73,7 +73,7 @@
 
       .flex-center(ng-show="display.action == 'email' && display.editingEmail")       
         p(translate="YOUR_EMAIL_ADDRESS")
-        bc-async-input(inline security-center type="email", placeholder="'EMAIL_ADDRESS' | translate", ng-model="user.email", on-save="changeEmail", action-title="'CHANGE_EMAIL_ADDRESS' | translate", autofocus)
+        bc-async-input(inline security-center type="email" ng-required="true" placeholder="'EMAIL_ADDRESS' | translate", ng-model="user.email", on-save="changeEmail", action-title="'CHANGE_EMAIL_ADDRESS' | translate", autofocus)
       .flex-center(ng-show="display.action == 'securityphrase'")        
         p.flex-1.prl(translate="RECOVERY_PHRASE_SECURITY_CENTER")
         .flex-1.mll.backup-phrase-actions
@@ -82,10 +82,10 @@
       div(ng-show="display.action == 'passwordhint'")       
         bc-async-input(custom inline security-center placeholder="'CHANGE_PASSWORD_HINT' | translate" ng-model="user.passwordHint" on-save="changePasswordHint" action-title="'CHANGE_PASSWORD_HINT' | translate")
           .flex-center
-            .form-group.width-50.flex-column
+            .form-group.width-50.flex-column(ng-class="{'has-error': !validate()}")
               p(translate="CHANGE_PASSWORD_HINT_SECURITY_CENTER")
               input.form-control.mtm(on-enter="save()" type="{{ type }}", ng-model="form.newValue", ng-focus="focus()", placeholder="{{ placeholder }}" ng-change="onChange()")
-              span {{ errorMessage }}  
+              span.help-block {{ errorMessage }}  
             .width-50.mll.pll
               button.button-success.button-lg(ng-click="save()",ng-disabled="!validate() || form.newValue == ngModel",ui-ladda="{{ status.saving }}", ladda-translate="SAVE", data-style="expand-left")
 

--- a/app/partials/security-center.jade
+++ b/app/partials/security-center.jade
@@ -73,7 +73,7 @@
 
       .flex-center(ng-show="display.action == 'email' && display.editingEmail")       
         p(translate="YOUR_EMAIL_ADDRESS")
-        bc-async-input.width-100.pll(inline security-center type="email" ng-required="true" placeholder="'EMAIL_ADDRESS' | translate", ng-model="user.email", on-save="changeEmail", action-title="'CHANGE_EMAIL_ADDRESS' | translate", autofocus)
+        bc-async-input.width-100.pll(inline security-center type="email" is-required="true" placeholder="'EMAIL_ADDRESS' | translate", ng-model="user.email", on-save="changeEmail", action-title="'CHANGE_EMAIL_ADDRESS' | translate", autofocus)
       .flex-center(ng-show="display.action == 'securityphrase'")        
         p.flex-1.prl(translate="RECOVERY_PHRASE_SECURITY_CENTER")
         .flex-1.mll.backup-phrase-actions

--- a/app/partials/settings/my-details.jade
+++ b/app/partials/settings/my-details.jade
@@ -13,7 +13,7 @@ form.form-horizontal(role="form",name="form",novalidate)
       span.label.label-success.hidden-sm.hidden-xs(translate="VERIFIED", ng-show="user.isEmailVerified")
       p.explain.hidden-xs(translate="EMAIL_ADDRESS_EXPLAIN")    
     .col-sm-12.col-md-6.setting-result.flex-column
-      bc-async-input(type="email", ng-required="true", ng-model="user.email", on-save="changeEmail", action-title="'CHANGE_EMAIL_ADDRESS' | translate", autofocus)
+      bc-async-input(type="email", is-required="true", ng-model="user.email", on-save="changeEmail", action-title="'CHANGE_EMAIL_ADDRESS' | translate", autofocus)
       verify-email
       resend-email-confirmation
   .form-group

--- a/app/partials/settings/my-details.jade
+++ b/app/partials/settings/my-details.jade
@@ -13,7 +13,7 @@ form.form-horizontal(role="form",name="form",novalidate)
       span.label.label-success.hidden-sm.hidden-xs(translate="VERIFIED", ng-show="user.isEmailVerified")
       p.explain.hidden-xs(translate="EMAIL_ADDRESS_EXPLAIN")    
     .col-sm-12.col-md-6.setting-result.flex-column
-      bc-async-input(type="email", ng-model="user.email", on-save="changeEmail", action-title="'CHANGE_EMAIL_ADDRESS' | translate", autofocus)
+      bc-async-input(type="email", ng-required="true", ng-model="user.email", on-save="changeEmail", action-title="'CHANGE_EMAIL_ADDRESS' | translate", autofocus)
       verify-email
       resend-email-confirmation
   .form-group

--- a/app/templates/bc-async-input.jade
+++ b/app/templates/bc-async-input.jade
@@ -3,7 +3,7 @@ div
     h2.status.complete.hidden-xs.long-input {{ ngModel }}
     button.button-primary(ng-click="edit()") {{ actionTitle }}
   form(role="form" name="bcAsyncForm" novalidate)
-    .form-group(ng-class="{'has-error': bcAsyncForm.$invalid && bcAsyncForm.$dirty}" ng-show="inline || status.edit")
+    .form-group(ng-class="{'has-error': bcAsyncForm.$invalid && bcAsyncForm.$dirty && !bcAsyncForm.input.$error.required}" ng-show="inline || status.edit")
       input.form-control(on-enter="save()" is-valid="validate()" ng-required="isRequired" name="input" type="{{ type }}" ng-model="form.newValue" ng-focus="focus()" placeholder="{{ placeholder }}" ng-class="{'width-100' : securityCenter}" ng-change="onChange()")
       span.help-block {{ errorMessage }}  
       span(ng-hide="inline && !status.edit")

--- a/app/templates/bc-async-input.jade
+++ b/app/templates/bc-async-input.jade
@@ -4,8 +4,8 @@ div
     button.button-primary(ng-click="edit()") {{ actionTitle }}
   form(role="form" name="bcAsyncForm" novalidate)
     .form-group(ng-class="{'has-error': bcAsyncForm.$invalid && bcAsyncForm.$dirty}" ng-show="inline || status.edit")
-      input.form-control(on-enter="save()" is-valid="validate()" name="input" type="{{ type }}" ng-model="form.newValue" ng-focus="focus()" placeholder="{{ placeholder }}" ng-class="{'width-100' : securityCenter}" ng-change="onChange()")
+      input.form-control(on-enter="save()" is-valid="validate()" ng-required="isRequired" name="input" type="{{ type }}" ng-model="form.newValue" ng-focus="focus()" placeholder="{{ placeholder }}" ng-class="{'width-100' : securityCenter}" ng-change="onChange()")
       span.help-block {{ errorMessage }}  
       span(ng-hide="inline && !status.edit")
-        button(ng-click="save()" ng-disabled="disableSubmit()" ui-ladda="{{ status.saving }}" ladda-translate="SAVE" data-style="expand-left" ng-class="securityCenter ? 'button-success button-lg' : 'button-primary btn-small'")
+        button(ng-click="save()" ng-disabled="bcAsyncForm.$invalid || bcAsyncForm.$pristine || noChange()" ui-ladda="{{ status.saving }}" ladda-translate="SAVE" data-style="expand-left" ng-class="securityCenter ? 'button-success button-lg' : 'button-primary btn-small'")
         button.button-muted.btn-small.mlm(ng-click="cancel(); onChange()" translate="CANCEL" ng-hide="status.saving")

--- a/app/templates/bc-async-input.jade
+++ b/app/templates/bc-async-input.jade
@@ -7,5 +7,5 @@ div(ng-class="{'width-100 pll' : securityCenter}")
       input.form-control(on-enter="save()" is-valid="validate()" name="input" type="{{ type }}" ng-model="form.newValue" ng-focus="focus()" placeholder="{{ placeholder }}" ng-class="{'width-100' : securityCenter}" ng-change="onChange()")
       span.help-block {{ errorMessage }}  
       span(ng-hide="inline && !status.edit")
-        button(ng-click="save()" ng-disabled="bcAsyncForm.$invalid || bcAsyncForm.$pristine" ui-ladda="{{ status.saving }}" ladda-translate="SAVE" data-style="expand-left" ng-class="securityCenter ? 'button-success button-lg' : 'button-primary btn-small'")
+        button(ng-click="save()" ng-disabled="disableSubmit()" ui-ladda="{{ status.saving }}" ladda-translate="SAVE" data-style="expand-left" ng-class="securityCenter ? 'button-success button-lg' : 'button-primary btn-small'")
         button.button-muted.btn-small.mlm(ng-click="cancel(); onChange()" translate="CANCEL" ng-hide="status.saving")

--- a/app/templates/bc-async-input.jade
+++ b/app/templates/bc-async-input.jade
@@ -1,4 +1,4 @@
-div(ng-class="{'width-100 pll' : securityCenter}")
+div
   div(ng-hide="status.edit || inline")
     h2.status.complete.hidden-xs.long-input {{ ngModel }}
     button.button-primary(ng-click="edit()") {{ actionTitle }}

--- a/assets/js/directives/bc-async-input.js.coffee
+++ b/assets/js/directives/bc-async-input.js.coffee
@@ -11,7 +11,7 @@ walletApp.directive('bcAsyncInput', ($timeout, Wallet) ->
       actionTitle: '='
       placeholder: '='
       type: '@'
-      ngRequired: '@'
+      isRequired: '@'
       errorMessage: '='
     }
     transclude: true
@@ -50,21 +50,21 @@ walletApp.directive('bcAsyncInput', ($timeout, Wallet) ->
         val = scope.form.newValue
         return true unless scope.validator?
         return scope.validator(val)
-        
+
       # Additional constraints (view already checks if the form is changed and valid)
       scope.disableSubmit = () ->
         val = scope.form.newValue
         return true if scope.bcAsyncForm.$invalid
         return true if scope.bcAsyncForm.$pristine
         return true if val == ctrl.$viewValue.toString() # Not the same as $pristine
-        return true if scope.ngRequired && val == ""
+        return true if scope.isRequired && val == ""
         return false
 
       scope.save = () ->
         scope.status.saving = true
-        
+
         success = () ->
-          unless attrs.custom? 
+          unless attrs.custom?
             scope.bcAsyncForm.$setPristine()
           scope.status.saving = false
           scope.status.edit = false

--- a/assets/js/directives/bc-async-input.js.coffee
+++ b/assets/js/directives/bc-async-input.js.coffee
@@ -47,18 +47,12 @@ walletApp.directive('bcAsyncInput', ($timeout, Wallet) ->
         scope.status.edit = 1
 
       scope.validate = () ->
-        val = scope.form.newValue
         return true unless scope.validator?
-        return scope.validator(val)
+        return scope.validator(scope.form.newValue)
 
-      # Additional constraints (view already checks if the form is changed and valid)
-      scope.disableSubmit = () ->
-        val = scope.form.newValue
-        return true if scope.bcAsyncForm.$invalid
-        return true if scope.bcAsyncForm.$pristine
-        return true if val == ctrl.$viewValue.toString() # Not the same as $pristine
-        return true if scope.isRequired && val == ""
-        return false
+      scope.noChange = () ->
+        return false if scope.form.newValue == ''
+        return scope.form.newValue == ctrl.$viewValue.toString()
 
       scope.save = () ->
         scope.status.saving = true

--- a/assets/js/directives/bc-async-input.js.coffee
+++ b/assets/js/directives/bc-async-input.js.coffee
@@ -11,6 +11,7 @@ walletApp.directive('bcAsyncInput', ($timeout, Wallet) ->
       actionTitle: '='
       placeholder: '='
       type: '@'
+      ngRequired: '@'
       errorMessage: '='
     }
     transclude: true
@@ -47,15 +48,24 @@ walletApp.directive('bcAsyncInput', ($timeout, Wallet) ->
 
       scope.validate = () ->
         val = scope.form.newValue
-        return false if val == ctrl.$viewValue.toString()
-        return false if val == ''
         return true unless scope.validator?
         return scope.validator(val)
+        
+      # Additional constraints (view already checks if the form is changed and valid)
+      scope.disableSubmit = () ->
+        val = scope.form.newValue
+        return true if scope.bcAsyncForm.$invalid
+        return true if scope.bcAsyncForm.$pristine
+        return true if val == ctrl.$viewValue.toString() # Not the same as $pristine
+        return true if scope.ngRequired && val == ""
+        return false
 
       scope.save = () ->
         scope.status.saving = true
-
+        
         success = () ->
+          unless attrs.custom? 
+            scope.bcAsyncForm.$setPristine()
           scope.status.saving = false
           scope.status.edit = false
 


### PR DESCRIPTION
* add ng-required to bc-async-input
* allow blank, by default
* disableSubmit() function
* if a field can not be empty, it won't be considered an error (red line), but submit will be disabled