### PR TITLE
fix(transactions-feed): watch the account index and fetch more tx's f…

### DIFF
--- a/app/partials/transactions.jade
+++ b/app/partials/transactions.jade
@@ -19,7 +19,7 @@
         p.em-400(translate="DESCRIBE_TRANSACTIONS")
       h3.em-100.center-align.mid-grey.emptystate(translate="HIT_RECEIVE", ng-click="request()")
       h3.em-100.center-align.mid-grey.emptystate(translate="HIT_SEND", ng-click="send()")
-    .flex-center.flex-justify.flex-column.mtl(ng-show="(transactions | filter:transactionFilter).length == 0 && getTotal(accountIndex) > 0")
+    .flex-center.flex-justify.flex-column.mtl(ng-show="(transactions | filter:transactionFilter).length == 0 && getTotal(accountIndex) > 0 && loading == 'false'")
       i.ti-search.h1.mrm
       h3.em-100.mbl(translate="SORRY_ZERO_TXS")
       p.em-400(translate="PLEASE_TRY_AGAIN", ui-sref="wallet.common.support")

--- a/assets/js/controllers/transactions_ctrl.js.coffee
+++ b/assets/js/controllers/transactions_ctrl.js.coffee
@@ -1,5 +1,4 @@
 walletApp.controller "TransactionsCtrl", ($scope, Wallet, MyWallet, $log, $stateParams, $timeout, $state) ->
-
   $scope.filterTypes = ['ALL', 'SENT', 'RECEIVED_BITCOIN_FROM', 'MOVED_BITCOIN_TO']
 
   $scope.setFilterType = (type) ->
@@ -33,6 +32,10 @@ walletApp.controller "TransactionsCtrl", ($scope, Wallet, MyWallet, $log, $state
     transaction.toggled = !transaction.toggled
 
   $scope.getTotal = (i) -> $scope.total(i)
+
+  $scope.$watch 'selectedAccountIndex', (newVal) ->
+    if newVal != 'accounts'
+      $scope.nextPage()
 
   #################################
   #           Private             #

--- a/tests/controllers/transactions_ctrl_spec.coffee
+++ b/tests/controllers/transactions_ctrl_spec.coffee
@@ -6,58 +6,69 @@ describe "TransactionsCtrl", ->
   beforeEach ->
     angular.mock.inject ($injector, $rootScope, $controller) ->
       Wallet = $injector.get("Wallet")
+      MyWallet = $injector.get("MyWallet")
+
+      MyWallet.wallet =
+        hdwallet:
+          accounts: [
+            { label: "Checking", index: 0, archived: false, balance: 100 }
+            { label: "Savings", index: 1, archived: false, balance: 175 }
+            { label: "Spending", index: 2, archived: false, balance: 0 }
+            { label: "Partay", index: 3, archived: true, balance: 50 }
+          ]
+
+      Wallet.status =
+        isLoggedIn: true
+        didLoadBalances: true
 
       scope = $rootScope.$new()
 
       $controller "TransactionsCtrl",
         $scope: scope,
-        $stateParams: {}
 
-      scope.transactions = Wallet.transactions
+      scope.selectedAcountIndex = 1
 
       return
 
     return
 
-  it "should have access to address book",  inject(() ->
-    pending()
-    expect(scope.addressBook).toBeDefined()
-    expect(scope.addressBook["17gJCBiPBwY5x43DZMH3UJ7btHZs6oPAGq"]).toBe("John")
-  )
+  describe "the transctions controller", ->
 
-  it "should be able to fetch more transactions", inject((Wallet) ->
-    spyOn(Wallet, "fetchMoreTransactions")
-    scope.nextPage()
-    expect(Wallet.fetchMoreTransactions).toHaveBeenCalled()
-  )
+    it "should have access to address book",  inject(() ->
+      pending()
+      expect(scope.addressBook).toBeDefined()
+      expect(scope.addressBook["17gJCBiPBwY5x43DZMH3UJ7btHZs6oPAGq"]).toBe("John")
+    )
 
-  it "should receive a new transaction from mock after 3 seconds on account 1",  inject((MyWallet, Wallet, $timeout) ->
-    pending() # Not sure how to test this with stateParams
-    # before = Wallet.transactions.length
-    #
-    # MyWallet.mockSpontanuousBehavior()
-    # $timeout.flush()
-    # expect(Wallet.transactions.length).toBe(before + 1)
-  )
+    it "should be able to fetch more transactions", inject((Wallet) ->
+      spyOn(Wallet, "fetchMoreTransactions")
+      scope.nextPage()
+      expect(Wallet.fetchMoreTransactions).toHaveBeenCalled()
+    )
 
-  it "should have 4 transaction types", inject(() ->
-    expect(scope.filterTypes.length).toEqual(4)
-  )
+    it "should receive a new transaction from mock after 3 seconds on account 1",  ->
+      pending() # Not sure how to test this with stateParams
 
-  it "can filter by transaction type", inject((Wallet) ->
-    spyOn(scope, "setFilterType")
-    scope.setFilterType(3)
-    expect(scope.setFilterType).toHaveBeenCalled()
-  )
+    it "should fetch more transcations when a new account is selected", ->
+      spyOn(scope, "nextPage")
+      scope.selectedAcountIndex = 2
+      scope.$digest()
+      expect(scope.nextPage).toHaveBeenCalled()
 
-  it "can filter by search", inject((Wallet) ->
-    spyOn(scope, "filterSearch")
-    scope.filterSearch(1, "test")
-    expect(scope.filterSearch).toHaveBeenCalled()
-  )
+    it "should have 4 transaction types", ->
+      expect(scope.filterTypes.length).toEqual(4)
 
-  it "can toggle a transaction's details", inject((Wallet) ->
-    spyOn(scope, "toggleTransaction")
-    scope.toggleTransaction(scope.transactions[0])
-    expect(scope.toggleTransaction).toHaveBeenCalled()
-  )
+    it "can filter by transaction type", ->
+      spyOn(scope, "setFilterType")
+      scope.setFilterType(3)
+      expect(scope.setFilterType).toHaveBeenCalled()
+
+    it "can filter by search", ->
+      spyOn(scope, "filterSearch")
+      scope.filterSearch(1, "test")
+      expect(scope.filterSearch).toHaveBeenCalled()
+
+    it "can toggle a transaction's details", ->
+      spyOn(scope, "toggleTransaction")
+      scope.toggleTransaction(scope.transactions[0])
+      expect(scope.toggleTransaction).toHaveBeenCalled()


### PR DESCRIPTION
…or that account, update test suite with mocked up MyWallet

Description: 
This is in regards to the empty state showing up for accounts that have transactions that don't load in the initial fetch