### PR TITLE
fix(upgrade): Insist on 2nd password more clearly. Show spinner.

### DIFF
--- a/app/partials/upgrade.jade
+++ b/app/partials/upgrade.jade
@@ -2,7 +2,9 @@
   i.h3.mrm.ti-alert
   h3(translate="UPGRADE_WALLET")        
 .modal-body
+  alert(type="danger", close="insist = false", ng-show="insist")
+    span(translate="NEED_SECOND_PASSWORD_FOR_UPGRADE")
   p(translate="UPGRADE_WALLET_EXPLAIN")
 .modal-footer.pal.flex-end
-  button.button-muted.mrm(ng-click="cancel()", translate="CANCEL")
-  button.button-danger(ng-click="close()" ng-disabled="waiting" translate="PROCEED")
+  button.button-muted.mrm(ng-click="cancel()", translate="CANCEL", ng-disabled="busy")
+  button.button-danger(ui-ladda="{{ busy }}", ng-click="upgrade()" ng-disabled="waiting", ladda-translate="PROCEED", data-style="expand-left")

--- a/assets/js/controllers/app_ctrl.js.coffee
+++ b/assets/js/controllers/app_ctrl.js.coffee
@@ -142,22 +142,19 @@ walletApp.controller "AppCtrl", ($scope, Wallet, $state, $rootScope, $location, 
         defer: ->
           defer
     )
-    
+
     modalInstance.result.then(
       () ->,
       () ->
         defer.reject()
     )
 
-  $scope.$on "needsUpgradeToHD", (notification, continueCallback) ->
+  $scope.$on "needsUpgradeToHD", (notification) ->
     modalInstance = $modal.open(
       templateUrl: "partials/upgrade.jade"
       controller: "UpgradeCtrl",
       backdrop: "static" # Undismissable
       windowClass: "bc-modal"
-    )
-    modalInstance.result.then(() ->
-      continueCallback()
     )
 
   $scope.back = () ->

--- a/assets/js/controllers/upgrade_ctrl.js.coffee
+++ b/assets/js/controllers/upgrade_ctrl.js.coffee
@@ -1,11 +1,25 @@
 walletApp.controller "UpgradeCtrl", ($scope, Wallet, $modalInstance, $log, $window, $translate, $timeout) ->
 
   $scope.waiting = true
+  $scope.busy = false
 
-  $scope.close = () ->
-    $modalInstance.close()
+
+  $scope.upgrade = () ->
+    secondPasswordCancelled = () ->
+      # Keep trying, user cannot use the wallet without upgrading.
+      $scope.insist = true
+      $scope.busy = false
+
+    success = () ->
+      $scope.busy = false
+      $modalInstance.close()
+
+    $scope.insist = false
+    $scope.busy = true
+    Wallet.upgrade(success, secondPasswordCancelled)
 
   $scope.cancel = () ->
+    $scope.busy = false
     $window.location = "https://blockchain.info/"
 
   $timeout ->

--- a/assets/js/services/wallet.js.coffee
+++ b/assets/js/services/wallet.js.coffee
@@ -203,6 +203,27 @@ walletServices.factory "Wallet", ($log, $http, $window, $timeout, MyWallet, MyBl
     else
       betaCheckFinished()
 
+  wallet.upgrade = (successCallback, cancelSecondPasswordCallback) ->
+    # if success after upgrade
+    success = () ->
+      wallet.status.didUpgradeToHd = true
+      wallet.status.didInitializeHD = true
+      wallet.my.getHistoryAndParseMultiAddressJSON()
+      successCallback()
+      wallet.applyIfNeeded()
+    # if failure saving upgrade
+    error = () ->
+      wallet.store.enableLogout()
+      wallet.store.setIsSynchronizedWithServer(true);
+      $window.location.reload()
+
+    proceed = (password) ->
+      $translate("FIRST_ACCOUNT_NAME").then (translation) ->
+        wallet.my.wallet.newHDWallet(translation, password, success, error)
+
+    wallet.askForSecondPasswordIfNeeded().then(proceed).catch(cancelSecondPasswordCallback)
+
+
 
   wallet.legacyAddresses = () ->
     wallet.my.wallet.keys
@@ -809,30 +830,8 @@ walletServices.factory "Wallet", ($log, $http, $window, $timeout, MyWallet, MyBl
     else if event == "on_wallet_decrypt_finish" # Non-HD part is decrypted
     else if event == "hd_wallets_does_not_exist"
       wallet.status.didUpgradeToHd = false
-      continueCallback = () ->
-        $translate("FIRST_ACCOUNT_NAME").then (translation) ->
-
-          cancel = () ->
-            # Keep trying, user cannot use the wallet without upgrading.
-            wallet.displayError("Unable to upgrade your wallet. Please try again.")
-            wallet.askForSecondPasswordIfNeeded().then(proceed).catch(cancel)
-          # if success after upgrade
-          success = () ->
-            wallet.status.didUpgradeToHd = true
-            wallet.status.didInitializeHD = true
-            wallet.my.getHistoryAndParseMultiAddressJSON()
-          # if failure saving upgrade
-          error = () ->
-            wallet.store.enableLogout()
-            wallet.store.setIsSynchronizedWithServer(true);
-            $window.location.reload()
-          proceed = (password) ->
-            wallet.my.wallet.newHDWallet(translation, password, success, error)
-
-          wallet.askForSecondPasswordIfNeeded().then(proceed).catch(cancel)
-
       $timeout(()->
-        $rootScope.$broadcast "needsUpgradeToHD", continueCallback
+        $rootScope.$broadcast "needsUpgradeToHD"
         , 1000
       )
 

--- a/locales/en-human.json
+++ b/locales/en-human.json
@@ -304,6 +304,7 @@
   "SET_PASSWORD" : "Set Password",
   "UPGRADE_WALLET" : "Upgrade Your Wallet",
   "UPGRADE_WALLET_EXPLAIN" : "We would like to upgrade your wallet so you can use our new and improved website. Once updated, there is no way back. If for some reason you still need to use the old blockchain.info, please press Cancel to be taken back to the old version.",
+  "NEED_SECOND_PASSWORD_FOR_UPGRADE" : "Your second password is required to upgrade the wallet.",
   "PROCEED" : "Proceed",
   "PBKDF2_ITERATIONS" : "PBKDF2 Iterations",
   "PBKDF2_ITERATIONS_SECOND_PASSWORD" : "Second Password PBKDF2 Iterations",

--- a/tests/controllers/app_ctrl_spec.coffee
+++ b/tests/controllers/app_ctrl_spec.coffee
@@ -73,14 +73,6 @@ describe "AppCtrl", ->
       expect($modal.open).toHaveBeenCalled()
     )
 
-
-    it "should proceed if user agrees", inject(($modal, $q) ->
-      spyOn($modal, 'open').and.returnValue(mockModalInstance)
-      scope.$broadcast("needsUpgradeToHD", callbacks.proceed)
-      mockModalInstance.close()
-      expect(callbacks.proceed).toHaveBeenCalled()
-    )
-
   describe "redeem from email", ->
     it "should proceed after login", inject((Wallet, $rootScope, $timeout, $modal) ->
 

--- a/tests/controllers/upgrade_ctrl_spec.coffee
+++ b/tests/controllers/upgrade_ctrl_spec.coffee
@@ -1,5 +1,7 @@
 describe "UpgradeCtrl", ->
   scope = undefined
+  Wallet = undefined
+
   modalInstance =
     close: ->
     dismiss: ->
@@ -9,7 +11,6 @@ describe "UpgradeCtrl", ->
   beforeEach ->
     angular.mock.inject ($injector, $rootScope, $controller) ->
       Wallet = $injector.get("Wallet")
-      MyWallet = $injector.get("MyWallet")
 
       scope = $rootScope.$new()
 
@@ -22,9 +23,11 @@ describe "UpgradeCtrl", ->
 
     return
 
-  it "covers close", ->
-    scope.close()
-    return
+  it "should proceed if user agrees", inject(() ->
+    spyOn(Wallet, "upgrade")
+    scope.upgrade()
+    expect(Wallet.upgrade).toHaveBeenCalled()
+  )
 
   it "covers cancel", ->
     scope.cancel()


### PR DESCRIPTION
If the user cancels the 2nd password entry during upgrade, they'll be shown this.
<img width="644" alt="schermafbeelding 2015-08-25 om 14 31 36" src="https://cloud.githubusercontent.com/assets/10217/9466946/8ce70ec2-4b38-11e5-8011-a2df37594a8a.png">

In addition, we now show a spinner during the upgrade process and dismiss the modal afterwards. @abhisharma2 can you fix the blue background on the spinner before the merge?
<img width="486" alt="schermafbeelding 2015-08-25 om 14 45 44" src="https://cloud.githubusercontent.com/assets/10217/9466949/924b30a0-4b38-11e5-8907-6c508721a339.png">