### PR TITLE
Styleguide refactor

### DIFF
--- a/app/partials/alpha-agreement.jade
+++ b/app/partials/alpha-agreement.jade
@@ -9,7 +9,7 @@
       b THE SOFTWARE SUPPLIED TO USER IS IN ALPHA FORM AND SUPPLIED FOR TESTING PURPOSES ONLY. BUGS, CRASHES AND OTHER MALFUNCTIONS ARE ALMOST CERTAIN TO OCCUR. UNDER NO CIRCUMSTANCES MAY USER USE THE SOFTWARE SUPPLIED IN CONNECTION WITH THE ALPHA SERVICE TO SECURE MORE THAN $10 WORTH OF BITCOIN.
     p
       b ANY DISPUTES ARISING OUT OF THIS AGREEMENT WILL BE RESOLVED BY BINDING, INDIVIDUAL ARBITRATION AND THE PARTIES WAIVE THEIR RIGHTS TO GO TO COURT OR PARTICIPATE IN A CLASS ACTION LAWSUIT OR CLASS- WIDE ARBITRATION.
-  .bg-light-grey-alt.flex-column.mtl.pal
+  .bg-light-blue.flex-column.mtl.pal
     h2 1. Definitions
     p
       ol
@@ -48,7 +48,7 @@
           | Blockchain may modify the permitted use of or suspend User’s access to any Alpha Service at any time and for any reason. Alpha Services also may be unavailable or their performance may be negatively affected by scheduled maintenance. No service levels or other uptime guarantees apply to the Alpha Services. Blockchain may or may not, at its discretion, notify User in advance of scheduled maintenance, but Blockchain is unable to provide advance notice of unscheduled or emergency maintenance.
         li
           | 2.4. Alpha Use Information and Feedback. Alpha Use Information and Feedback. In consideration of the rights granted in this Agreement, User will provide Alpha Use Information, when and in the form reasonably requested by Blockchain. Blockchain will have a perpetual and irrevocable right to use, evaluate and otherwise exploit all Alpha Use Information for its own purposes. User will not use any Alpha Use Information except for its internal evaluation purposes. Blockchain has a perpetual and irrevocable right to use and exploit all Feedback and may use the Feedback without accounting or compensation to User. User will not provide any Alpha Use Information or Feedback unless it has all rights necessary to do so.
-  .bg-light-grey-alt.flex-column.mtl.pal
+  .bg-light-blue.flex-column.mtl.pal
     h2 3. Term and Termination
     p
       ul
@@ -64,7 +64,7 @@
           | 4.1. Use and Disclosure. User may not disclose any Confidential Information during the term of this Agreement or at any time during the three (3) year period following the end of the Term. If the Parties have executed a separate non-disclosure agreement (the “NDA”) and there is a conflict between the terms of the NDA and the terms of this Section 4.1, the terms of the NDA will control.
         li
           | 4.2. Publicity. Neither Party will issue any press release or public statement regarding this Agreement or any Alpha Use, Alpha Service or Alpha Materials unless Blockchain has approved in writing the time, form and content of the information to be disseminated to third parties or the public.
-  .bg-light-grey-alt.flex-column.mtl.pal
+  .bg-light-blue.flex-column.mtl.pal
     h2 5. DISCLAIMER OF WARRANTIES
     p
       ul
@@ -79,7 +79,7 @@
       ul
         li
           | 6.1. NEITHER BLOCKCHAIN NOR ANY OF ITS AFFILIATES OR LICENSORS WILL BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL OR OTHER CONSEQUENTIAL DAMAGES ARISING FROM OR RELATED TO THIS AGREEMENT, WHETHER IN AN ACTION IN CONTRACT, TORT (INCLUDING NEGLIGENCE) OR OTHERWISE, EVEN IF THE PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES. IN ANY CASE, THE AGGREGATE LIABILITY OF BLOCKCHAIN AND ITS AFFILIATES AND LICENSORS ARISING FROM OR RELATED TO THIS AGREEMENT WILL NOT EXCEED THE AMOUNTS PAID (IF ANY) BY USER TO BLOCKCHAIN UNDER THIS AGREEMENT.  
-  .bg-light-grey-alt.flex-column.mtl.pal
+  .bg-light-blue.flex-column.mtl.pal
     h2 7. Disputes Resolution by Binding Arbitration; Jury Trial Waiver; Class Action Waiver.
     p
       ul

--- a/app/partials/home.jade
+++ b/app/partials/home.jade
@@ -9,7 +9,7 @@
         .charts.hidden-xs.pos-rel
           h5.aaa.em-400.mbl(ng-class="{'mts' : transactions.length > 0 }" translate="BALANCE_BY_ACCOUNT")
           .widget.flex-center.flex-justify.pos-rel(ng-class="{ 'empty' : accounts().length == 1 || getTotal() == 0 }")
-            button.button-sm.em-500(ng-click="newAccount()" ng-class="accounts().length > 1 ? 'button-gradient' : 'button-primary'" translate="NEW_ACCOUNT")
+            button.button-sm.z-10.em-500(ng-click="newAccount()" ng-class="accounts().length > 1 ? 'button-default' : 'button-primary'" translate="NEW_ACCOUNT")
             h5.width-75.center-align.em-300(translate="HOME_NEW_ACCOUNT_MSG" ng-hide="accounts().length > 1")
             h5.width-75.center-align.em-300(ng-show="accounts().length > 1 && getTotal() == 0" translate="ALT_EMPTY_MSG")
             .pos-abs-chart(ng-hide="accounts().length > 1")

--- a/app/partials/privacy-policy.jade
+++ b/app/partials/privacy-policy.jade
@@ -8,7 +8,7 @@
       | Privacy Policy
     p Last Updated:
       | Tuesday, May 6th 2014
-  .bg-light-grey-alt.flex-column.mtl.pal
+  .bg-light-blue.flex-column.mtl.pal
     p
       | This Privacy Policy explains how information about you is collected, used and disclosed by Blockchain Ltd.
       | ("
@@ -29,7 +29,7 @@
       | practices and the ways you can help protect your privacy.
   .flex-column.pal
     h3 Collection of Information
-  .bg-light-grey-alt.flex-column.mtl.pal
+  .bg-light-blue.flex-column.mtl.pal
     h4 Information You Provide to Us
     p
       | We collect information you provide directly to us. For example, we
@@ -89,7 +89,7 @@
           |                     own privacy policies.
   .flex-column.pal
     h3 Collection of Information
-  .bg-light-grey-alt.flex-column.mtl.pal
+  .bg-light-blue.flex-column.mtl.pal
     h3 Use of Information
     p
       | We may use information about you for various purposes, including to:
@@ -121,7 +121,7 @@
         li Carry out any other purpose for which you provided the information.
   .flex-column.pal
     h3 Sharing of Information
-  .bg-light-grey-alt.flex-column.mtl.pal
+  .bg-light-blue.flex-column.mtl.pal
     p
       | We may share information about you as follows or as otherwise
       | described in this Privacy Policy:
@@ -155,14 +155,14 @@
           | cannot reasonably be used to identify you.
   .flex-column.pal
     h3 Security
-  .bg-light-grey-alt.flex-column.mtl.pal
+  .bg-light-blue.flex-column.mtl.pal
     p
       | We take reasonable measures to help protect information about you
       | from loss, theft, misuse and unauthorized access, disclosure, alteration
       | and destruction.
   .flex-column.pal
     h3 Your Choices
-  .bg-light-grey-alt.flex-column.mtl.pal
+  .bg-light-blue.flex-column.mtl.pal
     p
       ul
         li
@@ -182,7 +182,7 @@
           |                     or our ongoing business relations.
   .flex-column.pal
     h3 Contact Us
-  .bg-light-grey-alt.flex-column.mtl.pal
+  .bg-light-blue.flex-column.mtl.pal
     p
       | If you have any questions about this Privacy Policy, please contact us at privacy@blockchain.info
 .modal-footer.flex-end.pal

--- a/app/partials/request.jade
+++ b/app/partials/request.jade
@@ -62,10 +62,10 @@
           img(src="img/spinner.gif", ng-hide="status.didInitializeHD")  
           span(ng-show="status.didInitializeHD" single-click-select)
             | {{ paymentRequestAddress }}
-        p.black.mtm.flex-center.center-align(ng-show="!browserCanExecCommand || browserCanExecCommand && !highlighted")
+        p.black.mtm.flex-center(ng-show="!browserCanExecCommand || browserCanExecCommand && !highlighted")
           i.ti-mouse-alt.mrs
           span(translate="COPY_ADDRESS")
-        p.success.mtm.flex-center.center-align(ng-show="browserCanExecCommand && highlighted")
+        p.success.mtm.flex-center(ng-show="browserCanExecCommand && highlighted")
           i.ti-check.mrs
           span Successfully copied to your clipboard!
 .modal-footer.flex-end.pal

--- a/app/partials/security-center.jade
+++ b/app/partials/security-center.jade
@@ -4,7 +4,7 @@
       h1.prm.type-h4(translate="LEVEL_1")
       h2.type-h5.mid-grey-alt.em-300(translate="LEVEL_1_TITLE")
     ul.flex.flex-start.pln.mbn
-      li.level-header.bg-light-grey-alt.flex-center.flex-justify
+      li.level-header.bg-light-blue.flex-center.flex-justify
         img(src="img/security-icon-1.png")
       li.level-badge(ng-class="{'badge-active': user.isEmailVerified}")
         a(ng-click="user.isEmailVerified || toggle('email')", ng-class="{'active' : display.action == 'email' }")
@@ -80,7 +80,7 @@
       h1.prm.type-h4(translate="LEVEL_2")
       h2.type-h5.mid-grey-alt.em-300(translate="LEVEL_2_TITLE")
     ul.flex.flex-start.pln.mbn
-      li.level-header.bg-light-grey-alt.flex-center.flex-justify
+      li.level-header.bg-light-blue.flex-center.flex-justify
         img(src="img/security-icon-2.png")
       li.level-badge(ng-class="{'badge-active': user.isMobileVerified}")
         a(ng-click="user.isMobileVerified || toggle('mobilenumber')", ng-class="{'active' : display.action == 'mobilenumber' }")
@@ -121,7 +121,7 @@
       h1.prm.type-h4(translate="LEVEL_3")
       h2.type-h5.mid-grey-alt.em-300(translate="LEVEL_3_TITLE")
     ul.flex.flex-start.pln.mbn
-      li.level-header.bg-light-grey-alt.flex-center.flex-justify
+      li.level-header.bg-light-blue.flex-center.flex-justify
         img(src="img/security-icon-3.png")
       li.level-badge(ng-class="{'badge-active': settings.blockTOR}")
         a(ng-click="settings.blockTOR || toggle('blocktor')", ng-class="{'active' : display.action == 'blocktor' }")

--- a/app/partials/settings/accounts.jade
+++ b/app/partials/settings/accounts.jade
@@ -1,26 +1,24 @@
 h5.well.headliner.hidden-xs(translate="ACCOUNT_MANAGEMENT_EXPLAIN")
   
-.row.form-ctrl
-  .col-xs-12
-    .col-lg-6
-      input.filter.form-control(type="text" ng-model="searchText")
-    .hidden-xs.col-lg-6(align="right")
-      a.btn.btn-info.btn-bci(ng-click="newAccount()", translate="CREATE_NEW_ACCOUNT")
-      a.btn.btn-info.btn-bci(ng-click="transfer(address)" translate="TRANSFER_BETWEEN_ACCOUNTS" ng-show="numberOfActiveAccounts() > 1") (transfer)
+.row.pvl.flex-center
+  .col-lg-6
+    input.filter.form-control(type="text" ng-model="searchText")
+  .hidden-xs.col-lg-6(align="right")
+    a.button-primary.mrm(ng-click="newAccount()", translate="CREATE_NEW_ACCOUNT")
+    a.button-default(ng-click="transfer(address)" translate="TRANSFER_BETWEEN_ACCOUNTS" ng-show="numberOfActiveAccounts() > 1") (transfer)
 .row
   .col-xs-12
-    div.account-container.clearfix(ng-repeat="account in accounts() | filter:{archived: false, label: searchText}")
-      header
-        hgroup.clearfix
-          div.col-xs-6
-            h2
-              span(ng-bind-html="account.label | highlight:searchText")
-              span.label.label-primary(translate="DEFAULT", ng-show="isDefault(account)")
-          div.col-xs-6.balance
-            h3.btc(ng-show="account.balance != null") {{ account.balance | toBitCurrency:settings.btcCurrency }}
-            h3.fiat(btc="account.balance", ng-show="account.balance != null")
-      div.actions.col-xs-12
-        ul
+    .account-container.pam.mvm.clearfix(ng-repeat="account in accounts() | filter:{archived: false, label: searchText}")
+      .clearfix.flex-center.border-bottom.pbl
+        .col-xs-6
+          h2
+            span(ng-bind-html="account.label | highlight:searchText")
+            span.label.label-primary(translate="DEFAULT", ng-show="isDefault(account)")
+        .col-xs-6.right-align
+          p.man(ng-show="account.balance != null") {{ account.balance | toBitCurrency:settings.btcCurrency }}
+          p.man(btc="account.balance", ng-show="account.balance != null")
+      .col-xs-12.mtm
+        ul.man.pan
           li
             a(translate="RENAME",          ng-click="editAccount(account)")
           li

--- a/app/partials/settings/addresses.jade
+++ b/app/partials/settings/addresses.jade
@@ -1,15 +1,15 @@
 h5.well.headliner.hidden-xs(translate="MY_ADDRESSES_EXPLAIN_TEMP")
 
 .form-ctrl.flex-between.flex-center
-  .flex-1.mrl
-    input.filter(type="text", ng-model="searchText").form-control
-  .btn-group(dropdown is-open="display.account_dropdown_open")
-    button.btn.btn-info.dropdown-toggle.btn-bci(dropdown-toggle type="button", data-toggle="dropdown", aria-expanded="false")
-      span(translate="NEW_ADDRESS")
+  .mrl(dropdown is-open="display.account_dropdown_open")
+    button.button-primary.dropdown-toggle(dropdown-toggle type="button", data-toggle="dropdown", aria-expanded="false")
+      span.prs(translate="NEW_ADDRESS")
       span.caret
     ul.dropdown-menu(role="menu")
       li(ng-repeat="account in accounts() | filter:{archived: false}")
         a(ng-click="addAddressForAccount(account)") {{ account.label }}
+  .flex-1
+    input.filter(type="text", ng-model="searchText").form-control
 .row
   .col-xs-12.table-container
     table.responsive
@@ -33,7 +33,7 @@ p.mtl.hidden-xs(translate="ARCHIVED_ADDRESSES_EXPLAIN", ng-show="display.archive
 .flex-between.flex-center.form-ctrl(ng-show="display.imported")
   .flex-1.mrl
     input.filter(type="text", ng-model="searchTextLegacy").form-control
-  a.btn.btn-info.btn-bci(ng-click="importAddress()", translate="IMPORT_ADDRESS")
+  a.btn.btn-info(ng-click="importAddress()", translate="IMPORT_ADDRESS")
 
 .row(ng-show="display.imported")
   .col-xs-12.table-container

--- a/app/partials/settings/advanced.jade
+++ b/app/partials/settings/advanced.jade
@@ -3,34 +3,37 @@ h5.well.headliner.hidden-xs(translate="ADVANCED_EXPLAIN")
 form.form-horizontal(role="form",name="form",novalidate)  
   .form-group
     .col-sm-12.col-md-6
-      label(translate="WALLET_SECOND_PASSWORD")
+      .flex-center.mbm
+        label.mbn(translate="WALLET_SECOND_PASSWORD")
+        span.label.label-warning(ng-hide="settings.secondPassword", translate="DISABLED")    
+        span.label.label-success(translate="SECOND_PASSWORD_SET", ng-show="settings.secondPassword")
       p.explain.hidden-xs.hidden-sm(translate="WALLET_SECOND_PASSWORD_EXPLAIN")    
     .col-sm-12.col-md-6.setting-result
-      h2.status.incomplete.hidden-xs.hidden-sm.mbm(ng-hide="settings.secondPassword", translate="DISABLED")    
-      h2.status.complete.hidden-xs.hidden-sm.mbm(translate="SECOND_PASSWORD_SET", ng-show="settings.secondPassword")
       configure-second-password
 
   .form-group
     .col-sm-12.col-md-6
-      label(translate="REMEMBER_2FA")
+      .flex-center.mbm
+        label.mbn(translate="REMEMBER_2FA")
+        span.label.label-warning(ng-hide="settings.rememberTwoFactor", translate="DISABLED")
+        span.label.label-success(ng-show="settings.rememberTwoFactor", translate="ENABLED")
       p.explain.hidden-xs.hidden-sm(translate="REMEMBER_2FA_EXPLAIN")    
     .col-sm-12.col-md-6.setting-result
       div(ng-show="processToggleRememberTwoFactor")
         img(src="img/spinner.gif")
       div(ng-hide="processToggleRememberTwoFactor")
-        h2.status.incomplete.hidden-xs.hidden-sm(ng-hide="settings.rememberTwoFactor", translate="DISABLED")
-        h2.status.complete.hidden-xs.hidden-sm(ng-show="settings.rememberTwoFactor", translate="ENABLED")
       .mtl
         a.button-primary(ng-click="enableRememberTwoFactor()", translate="ENABLE_REMEMBER_2FA", ng-hide="settings.rememberTwoFactor")
         a.button-primary(ng-click="disableRememberTwoFactor()", translate="DISABLE_REMEMBER_2FA", ng-show="settings.rememberTwoFactor")
 
   .form-group
     .col-sm-12.col-md-6
-      label(translate="BLOCK_TOR")
+      .flex-center.mbm
+        label(translate="BLOCK_TOR")
+        span.label.label-warning(ng-hide="settings.blockTOR", translate="DISABLED")
+        span.label.label-success(ng-show="settings.blockTOR", translate="ENABLED")
       p.explain.hidden-xs.hidden-sm(translate="BLOCK_TOR_EXPLAIN")    
     .col-sm-12.col-md-6.setting-result
-      h2.status.incomplete.hidden-xs.hidden-sm(ng-hide="settings.blockTOR", translate="DISABLED")
-      h2.status.complete.hidden-xs.hidden-sm(ng-show="settings.blockTOR", translate="ENABLED")
       tor
 
   .form-group
@@ -63,7 +66,10 @@ form.form-horizontal(role="form",name="form",novalidate)
 
   .form-group
     .col-sm-12.col-md-6
-      label(translate="API_ACCESS")
+      .flex-center.mbm
+        label.mbn(translate="API_ACCESS")
+        span.label.label-warning(ng-hide="settings.apiAccess" translate="DISABLED")
+        span.label.label-success(ng-show="settings.apiAccess" translate="ENABLED")
       p.explain.hidden-xs.hidden-sm(translate="API_ACCESS_EXPLAIN")    
     .col-sm-12.col-md-6
       setting-toggle(
@@ -75,7 +81,10 @@ form.form-horizontal(role="form",name="form",novalidate)
 
   .form-group
     .col-sm-12.col-md-6
-      label(translate="LOGGING")
+      .flex-center.mbm
+        label.mbn(translate="LOGGING")
+        span.label.label-warning(ng-hide="settings.loggingLevel" translate="DISABLED")
+        span.label.label-success(ng-show="settings.loggingLevel" translate="ENABLED")
       p.explain.hidden-xs.hidden-sm(translate="LOGGING_EXPLAIN")    
     .col-sm-12.col-md-6
       setting-toggle(
@@ -87,9 +96,10 @@ form.form-horizontal(role="form",name="form",novalidate)
 
   .form-group
     .col-sm-12.col-md-6
-      label(translate="IP_WHITELIST_RESTRICT")
+      .flex-center.mbm
+        label.mbn(translate="IP_WHITELIST_RESTRICT")
+        span.label.label-warning(ng-hide="settings.restrictToWhitelist", translate="DISABLED")
+        span.label.label-success(ng-show="settings.restrictToWhitelist", translate="ENABLED")
       p.explain.hidden-xs.hidden-sm(translate="IP_WHITELIST_RESTRICT_EXPLAIN")    
     .col-sm-12.col-md-6.setting-result
-      h2.status.incomplete.hidden-xs.hidden-sm(ng-hide="settings.restrictToWhitelist", translate="DISABLED")
-      h2.status.complete.hidden-xs.hidden-sm(ng-show="settings.restrictToWhitelist", translate="ENABLED")
       ip-whitelist-restrict

--- a/app/partials/settings/mobile.jade
+++ b/app/partials/settings/mobile.jade
@@ -1,7 +1,7 @@
 h5.well.headliner(translate="PAIRING_CODE_EXPLAIN")
 
-a(ng-click="showPairingCode()", translate="SHOW_PAIRING_CODE", ng-hide="display.pairingCode")
-a(ng-click="hidePairingCode()", translate="HIDE_PAIRING_CODE", ng-show="display.pairingCode")
+a.button-primary(ng-click="showPairingCode()", translate="SHOW_PAIRING_CODE", ng-hide="display.pairingCode")
+a.button-default(ng-click="hidePairingCode()", translate="HIDE_PAIRING_CODE", ng-show="display.pairingCode")
 
 div.qr
   img(ng-show="loading" src="img/spinner.gif")

--- a/app/partials/settings/my-details.jade
+++ b/app/partials/settings/my-details.jade
@@ -2,9 +2,10 @@ h5.well.headliner.hidden-xs(translate="MY_DETAILS_EXPLAIN")
 form.form-horizontal(role="form",name="form",novalidate)  
   .form-group
     .col-sm-12.col-md-6
-      label(translate="EMAIL_ADDRESS")
-      span.label.label-warning.hidden-sm.hidden-xs(translate="UNVERIFIED", ng-show="!user.isEmailVerified")
-      span.label.label-success.hidden-sm.hidden-xs(translate="VERIFIED", ng-show="user.isEmailVerified")
+      .flex-center.mbm
+        label.mbn(translate="EMAIL_ADDRESS")
+        span.label.label-warning(translate="UNVERIFIED", ng-show="!user.isEmailVerified")
+        span.label.label-success(translate="VERIFIED", ng-show="user.isEmailVerified")
       p.explain.hidden-xs(translate="EMAIL_ADDRESS_EXPLAIN")    
     .col-sm-12.col-md-6.setting-result.flex-column
       bc-async-input(type="email" is-required ng-model="user.email" on-save="changeEmail" action-title="'CHANGE_EMAIL_ADDRESS' | translate" autofocus)
@@ -12,9 +13,10 @@ form.form-horizontal(role="form",name="form",novalidate)
       resend-email-confirmation.mtl
   .form-group
     .col-sm-12.col-md-6
-      label(translate="MOBILE_NUMBER")
-      span.label.label-warning.hidden-sm.hidden-xs(translate="UNVERIFIED", ng-show="!user.isMobileVerified")
-      span.label.label-success.hidden-sm.hidden-xs(translate="VERIFIED", ng-show="user.isMobileVerified")
+      .flex-center.mbm
+        label.mbn(translate="MOBILE_NUMBER")
+        span.label.label-warning(translate="UNVERIFIED", ng-show="!user.isMobileVerified")
+        span.label.label-success(translate="VERIFIED", ng-show="user.isMobileVerified")
       p.explain.hidden-xs(translate="MOBILE_NUMBER_EXPLAIN")    
     .col-sm-12.col-md-6.setting-result
       div(ng-show="mobileNumber.step == 0")
@@ -25,24 +27,29 @@ form.form-horizontal(role="form",name="form",novalidate)
       verify-mobile-number(on-success="mobileNumber.step = 0" ng-show="mobileNumber.step == 2")
   .form-group
     .col-sm-12.col-md-6
-      label(translate="ENABLE_TWO_STEP")
-      span.label.label-warning.hidden-sm.hidden-xs(translate="DISABLED", ng-show="!settings.needs2FA")
-      span.label.label-success.hidden-sm.hidden-xs(translate="ENABLED", ng-show="settings.needs2FA")
+      .flex-center.mbm
+        label.mbn(translate="ENABLE_TWO_STEP")
+        span.label.label-warning(translate="DISABLED", ng-show="!settings.needs2FA")
+        span.label.label-success(translate="ENABLED", ng-show="settings.needs2FA")
       p.explain.hidden-xs(translate="SC_CONFIGURE_2FA")    
     .col-sm-12.col-md-6.setting-result
       a.button-primary(ng-click="changeTwoFactor()" translate="CONFIGURE_2FA" ng-hide="settings.needs2FA")
       a.button-primary(ng-click="changeTwoFactor()" translate="DISABLE" ng-show="settings.needs2FA")
   .form-group
     .col-sm-12.col-md-6
-      label(translate="WALLET_PASSWORD")
+      .flex-center.mbm
+        label.mbn(translate="WALLET_PASSWORD")
+        span.label.label-success(translate="PASSWORD_SET")
       p.explain.hidden-xs(translate="WALLET_PASSWORD_EXPLAIN")
     .col-sm-12.col-md-6.setting-result
-      h2.status.complete.hidden-sm.hidden-xs.mbm(translate="PASSWORD_SET")
       a.button-primary(ng-click="changePassword()", translate="CHANGE_PASSWORD")
   .form-group(ng-class="{'has-error':errors.passwordHint}")
     .col-sm-12.col-md-6
-      label(translate="PASSWORD_HINT")
-      p.explain.hidden-sm.hidden-xs(translate="PASSWORD_HINT_EXPLAIN")    
+      .flex-center.mbm
+        label.mbn(translate="PASSWORD_HINT")
+        span.label.label-warning(translate="NOT_STORED", ng-show="!user.passwordHint")
+        span.label.label-success(translate="HINT_STORED", ng-show="user.passwordHint")
+      p.explain(translate="PASSWORD_HINT_EXPLAIN")    
     .col-sm-12.col-md-6.setting-result
       bc-async-input(ng-model="user.passwordHint" on-save="changePasswordHint" on-change="clearErrors" max-length="255" action-title="'CHANGE_PASSWORD_HINT' | translate")
     .help-block

--- a/app/partials/settings/wallet-recovery.jade
+++ b/app/partials/settings/wallet-recovery.jade
@@ -2,9 +2,10 @@ h5.well.headliner.hidden-xs(translate="WALLET_RECOVERY_EXPLAIN")
 form.form-horizontal(role="form" name="recoveryForm" novalidate)  
   .form-group
     .col-sm-12.col-md-6
-      label(translate="MY_RECOVERY_PHRASE")
-      span.label.label-danger.hidden-xs.hidden-sm(translate="UNCONFIRMED", ng-hide="status.didConfirmRecoveryPhrase ")
-      span.label.label-success.hidden-sm.hidden-xs(translate="VERIFIED", ng-show="status.didConfirmRecoveryPhrase")
+      .flex-center.mbm
+        label.mbn(translate="MY_RECOVERY_PHRASE")
+        span.label.label-danger(translate="UNCONFIRMED", ng-hide="status.didConfirmRecoveryPhrase ")
+        span.label.label-success(translate="VERIFIED", ng-show="status.didConfirmRecoveryPhrase")
       p.explain.hidden-xs.hidden-sm(translate="RECOVERY_PHRASE_EXPLAIN")    
     .col-sm-12.col-md-6.setting-result
       confirm-recovery-phrase

--- a/app/partials/terms-of-service.jade
+++ b/app/partials/terms-of-service.jade
@@ -9,7 +9,7 @@
       b THE SOFTWARE SUPPLIED TO USER IS IN ALPHA FORM AND SUPPLIED FOR TESTING PURPOSES ONLY. BUGS, CRASHES AND OTHER MALFUNCTIONS ARE ALMOST CERTAIN TO OCCUR. UNDER NO CIRCUMSTANCES MAY USER USE THE SOFTWARE SUPPLIED IN CONNECTION WITH THE ALPHA SERVICE TO SECURE MORE THAN $10 WORTH OF BITCOIN.
     p
       b ANY DISPUTES ARISING OUT OF THIS AGREEMENT WILL BE RESOLVED BY BINDING, INDIVIDUAL ARBITRATION AND THE PARTIES WAIVE THEIR RIGHTS TO GO TO COURT OR PARTICIPATE IN A CLASS ACTION LAWSUIT OR CLASS- WIDE ARBITRATION.
-  .bg-light-grey-alt.flex-column.mtl.pal
+  .bg-light-blue.flex-column.mtl.pal
     h2 1. Definitions
     p
       ol
@@ -48,7 +48,7 @@
           | Blockchain may modify the permitted use of or suspend User’s access to any Alpha Service at any time and for any reason. Alpha Services also may be unavailable or their performance may be negatively affected by scheduled maintenance. No service levels or other uptime guarantees apply to the Alpha Services. Blockchain may or may not, at its discretion, notify User in advance of scheduled maintenance, but Blockchain is unable to provide advance notice of unscheduled or emergency maintenance.
         li
           | 2.4. Alpha Use Information and Feedback. Alpha Use Information and Feedback. In consideration of the rights granted in this Agreement, User will provide Alpha Use Information, when and in the form reasonably requested by Blockchain. Blockchain will have a perpetual and irrevocable right to use, evaluate and otherwise exploit all Alpha Use Information for its own purposes. User will not use any Alpha Use Information except for its internal evaluation purposes. Blockchain has a perpetual and irrevocable right to use and exploit all Feedback and may use the Feedback without accounting or compensation to User. User will not provide any Alpha Use Information or Feedback unless it has all rights necessary to do so.
-  .bg-light-grey-alt.flex-column.mtl.pal
+  .bg-light-blue.flex-column.mtl.pal
     h2 3. Term and Termination
     p
       ul
@@ -64,7 +64,7 @@
           | 4.1. Use and Disclosure. User may not disclose any Confidential Information during the term of this Agreement or at any time during the three (3) year period following the end of the Term. If the Parties have executed a separate non-disclosure agreement (the “NDA”) and there is a conflict between the terms of the NDA and the terms of this Section 4.1, the terms of the NDA will control.
         li
           | 4.2. Publicity. Neither Party will issue any press release or public statement regarding this Agreement or any Alpha Use, Alpha Service or Alpha Materials unless Blockchain has approved in writing the time, form and content of the information to be disseminated to third parties or the public.
-  .bg-light-grey-alt.flex-column.mtl.pal
+  .bg-light-blue.flex-column.mtl.pal
     h2 5. DISCLAIMER OF WARRANTIES
     p
       ul
@@ -79,7 +79,7 @@
       ul
         li
           | 6.1. NEITHER BLOCKCHAIN NOR ANY OF ITS AFFILIATES OR LICENSORS WILL BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL OR OTHER CONSEQUENTIAL DAMAGES ARISING FROM OR RELATED TO THIS AGREEMENT, WHETHER IN AN ACTION IN CONTRACT, TORT (INCLUDING NEGLIGENCE) OR OTHERWISE, EVEN IF THE PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES. IN ANY CASE, THE AGGREGATE LIABILITY OF BLOCKCHAIN AND ITS AFFILIATES AND LICENSORS ARISING FROM OR RELATED TO THIS AGREEMENT WILL NOT EXCEED THE AMOUNTS PAID (IF ANY) BY USER TO BLOCKCHAIN UNDER THIS AGREEMENT.  
-  .bg-light-grey-alt.flex-column.mtl.pal
+  .bg-light-blue.flex-column.mtl.pal
     h2 7. Disputes Resolution by Binding Arbitration; Jury Trial Waiver; Class Action Waiver.
     p
       ul

--- a/app/templates/contextual-message.jade
+++ b/app/templates/contextual-message.jade
@@ -1,6 +1,6 @@
 .message.pointer(ng-hide="!message || dismissed")
   .message-beacon(ng-click="revealMsg()")
-  .message-contextual.bg-light-grey-alt.pal(ng-show="reveal")
+  .message-contextual.bg-light-blue.pal(ng-show="reveal")
     p.mbl.black.center-align(translate="{{::message}}")
     .flex-center.flex-between
       a.aaa(ng-click="dismissMessage(messageIndex + 1)", translate="NO_THANKS")

--- a/app/templates/did-you-know.jade
+++ b/app/templates/did-you-know.jade
@@ -7,7 +7,7 @@
   .widget
     .flex-center.mbm
       i.title.aaa(ng-class="dyk.icon")
-      p.h3.em-300.mll.center-align(ng-class="dyk.type.toLowerCase()") {{ dyk.title | translate }}
-    p.center-align.type-h6.lh-lg
+      p.h3.em-300.mll(ng-class="dyk.type.toLowerCase()") {{ dyk.title | translate }}
+    p.h4.em-300.lh-lg
       | {{ dyk.text | translate }}
       a.mls(href="{{ dyk.link }}") {{ dyk.linkText | translate }}

--- a/app/templates/setting-toggle.jade
+++ b/app/templates/setting-toggle.jade
@@ -1,6 +1,3 @@
 .setting-result
-  h2.status.incomplete.hidden-xs.hidden-sm(ng-hide="value" translate="DISABLED")
-  h2.status.complete.hidden-xs.hidden-sm(ng-show="value" translate="ENABLED")
-  .mtl
-    a.button-primary(ng-click="toggle()" translate="{{enableTitle}}" ng-hide="value")
-    a.button-primary(ng-click="toggle()" translate="{{disableTitle}}" ng-show="value")
+  a.button-primary(ng-click="toggle()" translate="{{enableTitle}}" ng-hide="value")
+  a.button-primary(ng-click="toggle()" translate="{{disableTitle}}" ng-show="value")

--- a/assets/css/_bootstrap-blockchain.scss
+++ b/assets/css/_bootstrap-blockchain.scss
@@ -31,7 +31,6 @@
 @import "bootstrap/media";
 @import "bootstrap/list-group";
 @import "bootstrap/responsive-embed";
-@import "bootstrap/wells";
 @import "bootstrap/close";
 
 // Components w/ JavaScript

--- a/assets/css/blockchain.css.scss
+++ b/assets/css/blockchain.css.scss
@@ -13,6 +13,7 @@
 @import 'elements/buttons';
 @import 'elements/inputs';
 @import 'elements/links';
+@import 'elements/tables';
 @import 'elements/textareas';
 
 //import components
@@ -73,10 +74,7 @@ html,body {
   height: 20px;
   background: transparent;
 }
-.modal-dialog{
-  width: 100%;
-  margin: 0;
-}
+
 a.back {
  h4{
   background: url("/img/back.png") no-repeat left center;
@@ -87,58 +85,37 @@ a.back {
   text-decoration: none;
   }
 }
+
 .long-input{overflow-wrap:break-word; }
 
-.table-container{
- display: block;
- overflow-x: auto;
-}
-
-.form-ctrl{
+.form-ctrl {
   padding: 15px 0;
-    .btn-bci{
-      margin: 6px 0px 0 5px;
-    }
-    input{
+  .btn-bci{
+    margin: 6px 0px 0 5px;
+  }
+  input{
     border: 1px solid #CCC;
     border-radius: 5px;
     padding: 3px;
-    }
-    input.filter{
+  }
+  input.filter {
     background-image:url('/img/spyglass.png');
     background-repeat: no-repeat;
     background-position: 98% center;
     background-size: 20px;
-    }
   }
-
-
-table.responsive{
-  a{overflow-wrap: break-word;}
 }
 
 .container-fluid {
-padding-right: 5px;
-padding-left: 5px;
-}
-// this is naughty, and I need to put these styles in the appropriate places.
-
-@media (min-width: 768px){
-.tx-row .left-view{padding: 0 15px;}
-.tx-row .right-view {
-background-color: #FFFFFF;
+  padding-right: 5px;
+  padding-left: 5px;
 }
 
-.container-fluid {
-padding-right: 15px;
-padding-left: 15px;
-}
-
-.modal-dialog{
-  width: 70%;
-  margin: 10px auto;
-}
-
+@media (min-width: 768px) {
+  .container-fluid {
+    padding-right: 15px;
+    padding-left: 15px;
+  }
 }
 
 #qr-canvas { display: none; }

--- a/assets/css/blockchain.css.scss
+++ b/assets/css/blockchain.css.scss
@@ -90,19 +90,10 @@ a.back {
 
 .form-ctrl {
   padding: 15px 0;
-  .btn-bci{
-    margin: 6px 0px 0 5px;
-  }
   input{
-    border: 1px solid #CCC;
+    border: 1px solid $border-grey;
     border-radius: 5px;
     padding: 3px;
-  }
-  input.filter {
-    background-image:url('/img/spyglass.png');
-    background-repeat: no-repeat;
-    background-position: 98% center;
-    background-size: 20px;
   }
 }
 
@@ -146,3 +137,4 @@ a.back {
     user-select: none;
   }
 }
+.z-10 { z-index: 10; }

--- a/assets/css/components/_filter-bar.scss
+++ b/assets/css/components/_filter-bar.scss
@@ -2,9 +2,9 @@
   position: fixed;
   width: calc(100% - 270px);
   left: 270px;
-  top: 170px;
+  top: 165px;
   height: 50px;
-  background: $light-grey-alt;
+  background: $light-blue;
   padding: 0 30px;
   border-bottom: 1px solid #ddd;
   z-index: 1;
@@ -54,7 +54,8 @@
 @media (max-width: 768px) {
   .filter-bar {
     width: 100%;
-    top: 150px;
+    top: 130px;
     left: 0;
+    border-top: 1px solid $eee
   }
 }

--- a/assets/css/components/_forms.scss
+++ b/assets/css/components/_forms.scss
@@ -1,5 +1,5 @@
 .bc-form {
-  background: $light-grey-alt;
+  background: $light-blue;
   border: 1px solid $eee;
   border-radius: 5px;
   margin-bottom: 3em;

--- a/assets/css/components/_helpers.scss
+++ b/assets/css/components/_helpers.scss
@@ -1,7 +1,7 @@
 //class should be applied on elements that have a focus state
 .helper {
-  color: $border-grey;
-  border: 1px solid $border-grey;
+  color: $mid-grey;
+  border: 1px solid $mid-grey;
   border-radius: 100%;
   background-color: white;
   width: 20px;
@@ -14,7 +14,7 @@
     outline: none;
   }
   &.active {
-    background: $blue-alt;
+    background: $blue;
     color: white;
     border: none;
   }

--- a/assets/css/components/_modals.scss
+++ b/assets/css/components/_modals.scss
@@ -2,7 +2,7 @@
   display: flex !important;
   justify-content: center;
   align-items: center;
-  .modal-content { background: $light-grey-alt; box-shadow: 0 5px 1px rgba(0, 0, 0, 0.6); }
+  .modal-content { background: $light-blue; box-shadow: 0 5px 1px rgba(0, 0, 0, 0.6); }
   .modal-dialog { width: 50vw; margin: 0 !important }
   &.small { .modal-dialog { width: 40vw; } }
   .modal-body {

--- a/assets/css/elements/_buttons.scss
+++ b/assets/css/elements/_buttons.scss
@@ -92,11 +92,3 @@ button[disabled] {
   border: none;
 }
 .button-default { border: 1px solid #e0e0e0; }
-
-.button-gradient {
-  background: linear-gradient(#F6F6F6, #E2E2E2);
-  color: $black;
-  border: #D3D3D3;
-  border-radius: 5px;
-  z-index: 11;
-}

--- a/assets/css/elements/_inputs.scss
+++ b/assets/css/elements/_inputs.scss
@@ -14,3 +14,10 @@ input::-ms-clear {
 
 //Mozilla hide input spinners
 input[type=number] {-moz-appearance: textfield;}
+
+input.filter {
+  background-image:url('/img/spyglass.png');
+  background-repeat: no-repeat;
+  background-position: 98% center;
+  background-size: 20px;
+}

--- a/assets/css/elements/_tables.scss
+++ b/assets/css/elements/_tables.scss
@@ -1,0 +1,8 @@
+.table-container {
+  display: block;
+  overflow-x: auto;
+}
+
+table.responsive{
+  a {overflow-wrap: break-word;}
+}

--- a/assets/css/modules/_header.scss
+++ b/assets/css/modules/_header.scss
@@ -35,7 +35,7 @@
 .navbar-inverse .navbar-nav > li > a { color: white; }
 
 .navbar-inverse {
-  background-color: #049bd4;
+  background-color: $blue;
   border:none;
   border-radius: 0px;
   z-index: 1030;

--- a/assets/css/modules/_home.scss
+++ b/assets/css/modules/_home.scss
@@ -19,7 +19,7 @@
 
 .widget {
   padding: 1em;
-  border: 1px solid #eee;
+  border: 1px solid $grey;
   &.empty {
     background: RGBA(247, 247, 247, 1);
     height: 275px;
@@ -41,7 +41,7 @@
 .empty-state-chart {
   height: 200px;
   width: 200px;
-  border: 30px solid #E7E7E7;
+  border: 30px solid $grey;
   border-radius: 100%;
   position: relative;
   left: -50%;

--- a/assets/css/modules/_layout.scss
+++ b/assets/css/modules/_layout.scss
@@ -6,8 +6,8 @@
   height: 100%;
   padding: 15px;
   top: 65px;
-  background: $light-grey-alt;
-  border-right: 1px solid #ddd;
+  background: $light-blue;
+  border-right: 1px solid $border-grey;
   .active-accounts{
     margin-bottom: 30px;
   }
@@ -15,8 +15,8 @@
     margin-bottom: 30px;
   }
   .side-box {
-    background-color: #FDFDFD;
-    border: 1px solid rgb(229, 229, 229);
+    background-color: $light-grey;
+    border: 1px solid $grey;
   }
 }
 .top-view {
@@ -25,7 +25,7 @@
   z-index: 1;
   background: white;
   margin-left: 270px;
-  border-bottom: 1px solid #ddd;
+  border-bottom: 1px solid $border-grey;
   padding: 0 30px;
   height: 100px;
   top: 65px;
@@ -50,7 +50,7 @@
   background: white;
   position: relative;
   left: 270px;
-  top: 100px;
+  top: 90px;
   overflow-y: scroll;
   overflow-x: hidden;
   width: calc(100% - 270px);

--- a/assets/css/modules/_left-nav.scss
+++ b/assets/css/modules/_left-nav.scss
@@ -1,24 +1,7 @@
 .left-navigation {
-  color: #c9c9c9;
-  width: initial;
   height: 100%;
   @extend .flex-between;
   flex-direction: column;
-  -webkit-flex-direction: column;
-  a {
-    color: #c9c9c9;
-    cursor: pointer;
-  }
-}
-.sidebox{
-  header{
-    padding: 0px 15px 5px;
-    border-bottom: 1px solid #E8E8E8;
-    h3{
-      font-size: 1.25em;
-      color: #636363;
-    }
-  }
 }
 ul.aside {
   list-style: none;
@@ -57,7 +40,7 @@ ul.aside {
     }
     li.active{
       a{
-        color: #049BD4;
+        color: $blue;
         font-weight: 500;
         &:focus {
           text-decoration: none;
@@ -120,7 +103,7 @@ ul.aside {
   }
   ::-webkit-scrollbar-thumb {
     background: #fff;
-    border: 0px none #d4d4d4;
+    border: 0px none $border-grey;
     border-radius: 100px;
   }
   ::-webkit-scrollbar-thumb:hover {
@@ -130,7 +113,7 @@ ul.aside {
     background: #606060;
   }
   ::-webkit-scrollbar-track {
-    background: #ffffff;
+    background: white;
     border: 0px none #ff5a28;
     border-radius: 100px;
   }
@@ -147,17 +130,17 @@ ul.aside {
 
 
 li.action-bar{
-  background: #fff;
+  background: white;
   margin: -10px 0 5px;
   padding: 5px 15px;
-  box-shadow: 0px -2px 13px -9px black;
+  box-shadow: 0px -2px 13px -9px $black;
   border-top: 1px solid white;
   z-index: 1;
   position: relative;
 }
 .settings-nav { margin-top: 10px; }
 .settings-nav-header {
-  background: #EBEBEB;
+  background: $light-grey;
 }
 
 @media (max-width: 768px) {

--- a/assets/css/modules/_settings.scss
+++ b/assets/css/modules/_settings.scss
@@ -75,7 +75,7 @@
     }
 
     td, th {
-      border: 1px solid #E6E6E6;
+      border: 1px solid $border-grey;
       padding: 10px;
 
       .btc {
@@ -83,8 +83,7 @@
       }
 
       .fiat {
-        color: #9E9E9E;
-        font-style: italic;
+        color: $dark-grey;
         font-size: 80%;
         display: block;
       }
@@ -94,11 +93,11 @@
   form.form-horizontal{
   .form-group{
      margin: 0!important;
-   border-bottom: 1px solid #EFEFEF;
+   border-bottom: 1px solid $grey;
    padding: 20px 0;
 
      &:hover{
-      background: rgb(237, 246, 252);
+      background: $hover-blue;
      }
 
      label{
@@ -108,7 +107,7 @@
      }
 
      p.explain{
-    color: #9D9D9D;
+    color: $mid-grey;
     line-height: 1.6em;
     font-size: 10pt;
      }
@@ -118,32 +117,6 @@
        clear: both;
      }
     }
-  }
-}
-
-.left-view{
-  ul.nav{
-    padding: 20px;
-    background: #ffffff;
-
-    li{
-    a{
-    color: #adadad;
-    font-size: 110%;
-      &:hover{
-       background-color: #fff;
-         color: #75B0D3;
-      }
-    }
-    }
-
-    li.active{
-    a{
-     background: none;
-     color: #75B0D3;
-    }
-    }
-
   }
 }
 

--- a/assets/css/modules/_settings.scss
+++ b/assets/css/modules/_settings.scss
@@ -1,45 +1,20 @@
 #settings {
   padding: 15px 30px;
-  .label{
-    font-size: 85%;
+  .label {
     font-weight: normal;
     margin-left: 10px;
   }
   .label-warning {
-    background-color: #EA7E7E;
+    background-color: $security-red;
   }
-  label-success {
-    background-color: #84BB84;
-  }
-  .settings-list{
-    list-style: none;
-    text-align: left;
-    background: #F9F9F9;
-    padding: 20px;
-    border: 1px solid #F0F0F0;
+  .label-success {
+    background-color: $security-green;
   }
   .qr{
     padding: 20px 0;
   }
-  .header-with-label {
-    h2, label {
-      display: inline;
-    }
-    margin-bottom: 20px;
-  }
-  h2.status.incomplete {
-    color: #C89898;
-  }
-  h2{
+  h2 {
     font-size: 12pt;
-  }
-  p.headliner{
-    font-size: 115%;
-    color: #999;
-    line-height: 1.7em;
-    border-bottom: 1px solid #EAEAEA;
-    padding: 0 0 15px 0;
-    margin: 0 0 20px 0;
   }
   .right {
     a {
@@ -120,70 +95,36 @@
   }
 }
 
-.title{
-  h2{
-  margin: 0 0 15px 0;
-  }
+.title {
+  h2 { margin: 0 0 15px 0; }
   p{
    font-size: 120%;
    color: #AEAEAE;
   }
-
 }
 
 .setting-result {
   p { margin-top: 15px; }
 }
 
-
-.btn-group{
-  button{float: none;}
-}
 .inneredit{padding: 10px 15px 0;}
 
-.account-container{
-  border: 1px solid #EFEFEF;
-  padding: 5px;
-  margin: 10px 0 10px 0;
-  .label-primary{background-color: #7CA6CB;color: #fff;}
-    header{
-      border-bottom: 1px solid rgb(229, 229, 229);
-      padding: 0 0 5px 0;
-      margin: 0 0 15px 0;
-        h2{
-          background: url('/img/my-accounts-icon.png') no-repeat 0 0;
-          padding: 5px 0px 5px 40px;
-          background-size: 35px;
-          margin-bottom: 10px;
-          margin-top: 10px;
-            span{font-size: 13pt;word-break: break-word;color: #686868;margin-bottom: 10px;}
-            span.label{font-size: 10pt!important;}
-          }
-        h3.fiat{
-          font-size: 10pt;
-          font-style: italic;
-          color: #ccc;
-          margin: 0;
-          padding: 0;
-        }
-         h3.btc{
-          font-size: 12pt;
-          font-style: italic;
-          color: rgb(160, 160, 160);
-        }
-        .balance{
-          text-align: right;
-        }
-    }
-    ul{
-      margin: 0;
-      padding: 0;
-        list-style: none;
-        li{
-          padding: 2px 0;
-        }
-    }
-
+.account-container {
+  border: 1px solid $grey;
+  .label-primary {background-color: $blue; color: white;}
+  h2 {
+    background: url('/img/my-accounts-icon.png') no-repeat 0 0;
+    padding: 5px 0px 5px 40px;
+    background-size: 35px;
+    margin-bottom: 10px;
+    margin-top: 10px;
+    span{font-size: 13pt;word-break: break-word; color: #686868;margin-bottom: 10px;}
+    span.label{font-size: 10pt!important;}
+  }
+  ul {
+    list-style: none;
+    li { padding: 2px 0; }
+  }
 }
 
 .intl-tel-input { margin-bottom: 10px; }
@@ -195,11 +136,7 @@
   h2.status {
     margin: 0px 0px 15px;
   }
-  .btn-group{
-    button{float: left;}
-  }
 }
 @media (max-width: 991px) {
   .setting-result { margin-top: 10px; }
 }
-

--- a/assets/css/modules/_signin.scss
+++ b/assets/css/modules/_signin.scss
@@ -10,7 +10,7 @@ div.login-form {
 }
 
 .login-pg {
-  background-color: #049BD4;
+  background-color: $blue;
   height: calc(100% + 50px); //offset margin from bootstrap
 }
 
@@ -30,9 +30,9 @@ div.login-form {
     margin-right: auto;
   }
   .help-block .info {
-    color: #C9C9C9;
+    color: $mid-grey;
     &:hover {
-      color: #A3A0A0;
+      color: $dark-grey;
     }
   }
   input[type='checkbox'] { margin: 0; }

--- a/assets/css/modules/_transaction-list.scss
+++ b/assets/css/modules/_transaction-list.scss
@@ -3,10 +3,6 @@
     position: relative;
     top: 50px;
   }
-  .ui-select-highlight {
-   background: #D3E7D5;
-   font-weight: 400;
-  }
   a.date { padding-top: 10px; }
   .transaction {
     border-bottom: 1pt solid $light-grey;
@@ -29,13 +25,13 @@
       font-size: 1.3em;
     }
     .action.incoming_tx{
-    color: #85B45B;
+      color: $receive-green;
     }
     .action.outgoing_tx{
-     color: #E27E82;
+     color: $send-red;
     }
     .action.local_tx{
-     color: #5BACD0;
+     color: $transfer-blue;
     }
     .destination{
       display: block;
@@ -62,7 +58,7 @@
     }
   }
   .description {
-    color: #828181;
+    color: $dark-grey;
   }
   .feed-details {
     border-top: 1px solid $eee;
@@ -70,7 +66,7 @@
 }
 
 .transaction-card {
-  background-color: $light-grey-alt;
+  background-color: $light-blue;
   border: 1px solid $eee;
   border-radius: 5px;
   padding: 20px;
@@ -78,7 +74,7 @@
   margin: 10px auto;
   font-size: 1.1em;
   .tx-date{
-    border-bottom: 1px solid #DCDCDC;
+    border-bottom: 1px solid $border-grey;
     padding: 0 0px 15px 0;
     margin-bottom: 15px;
     color: #6C6C6C;
@@ -91,7 +87,6 @@
     p{
       margin: 0 10px 0px 0;
       font-weight: 600;
-      color: #777777;
     }
     strong{
       display: inline;
@@ -100,7 +95,7 @@
     }
   }
   .tx-sidebar{
-    border-left: 1px solid #DCDCDC;
+    border-left: 1px solid $border-grey;
   }
   .tx-status{
     font-weight: 600;
@@ -110,7 +105,7 @@
   .tx-notes{
     margin-top: 25px;
     padding-top: 25px;
-    border-top: 1px solid #E5E5E5;
+    border-top: 1px solid $grey;
     i{margin-right: 5px;}
 
   }
@@ -120,7 +115,7 @@
   .tx-value{
     text-align: center;
     margin-bottom: 10px;
-    p{font-size: .9em; margin: 0; color: darkgrey;}
+    p{font-size: .9em; margin: 0; }
     span{font-weight: bold; font-size: 1.3em;}
 
   }
@@ -151,9 +146,9 @@ button {
 }
 .unconfirmed { opacity: 0.5; }
 
-.note { color: #aeaeae; }
+.note { color: $black; }
 
-a.date,p.date { color: #adc0c9; }
+a.date,p.date { color: $black; }
 
 .amountTotal{ float: none;}
 

--- a/assets/css/utilities/_bs_overrides.scss
+++ b/assets/css/utilities/_bs_overrides.scss
@@ -86,7 +86,7 @@ $select-fg: #686868;
 .ui-select-bootstrap > .ui-select-choices {
   border-radius: 0;
   background: $select-bg;
-  border: 1px solid #E9E9E9; //you'll want to add this color in your sassy way
+  border: 1px solid $eee; //you'll want to add this color in your sassy way
   -webkit-box-shadow: 0px 5px 10px -6px black;
   box-shadow: 0px 5px 10px -6px black;
 }
@@ -132,17 +132,16 @@ $select-fg: #686868;
 }
 
 //A better .well class
-.well{
+.well {
   min-height: 20px;
   padding: 20px;
   margin-bottom: 20px;
-  background-color: #F7F7F7;
-  border: 1px solid #ECECEC;
+  background-color: $light-blue;
+  border: 1px solid $border-grey;
   border-radius: 5px;
   line-height: 2em;
   font-size: 1.2em;
   font-weight: 400;
-  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
 }
 
 //override BS modal-footer alignment craziness

--- a/assets/css/utilities/_colors.scss
+++ b/assets/css/utilities/_colors.scss
@@ -1,23 +1,28 @@
-$blue: #039BD3;
-$blue-alt: #049bd4;
-$hover-blue: #edf6fc;
-$black: #4B4D4E;
-$dark-blue: #0079A6;
-$deep-blue: #005380;
-$text: #6C6C6C;
-
-//HD Wallet Colors
-$transfer-blue: #5bacd0;
+//Blockchain Pillar Colors
+$blue: #1b8ac7;
 $send-red: #e27e82;
 $receive-green: #85b45b;
-$bright-green:  #3CC476 !important; //override Security Center nested css selectors
-$light-grey: #eaeff4;
-$light-grey-alt: #F5F7F9;
+$transfer-blue: #5bacd0;
+$pending-red: #ffbcbd;
+
+//Blockchain Blue Tints
+$hover-blue: #edf6fc;
+$light-blue: #F5F7F9;
+$light-blue-2: #eaeff4;
+$tertiary-blue: #D0E0E8;
+$dark-blue: #1476ab;
+$deep-blue: #005380;
+
+//Blockchain Text
+$black: #4B4D4E;
+$text: #6C6C6C;
+
+//Blockchain Greys
+$light-grey: #f7f7f7;
 $grey: #EEEEEE;
 $mid-grey: #b0b0b0;
-$mid-grey-alt: #9F9F9F;
-$dark-grey: #737373;
-$border-grey: #6d6d6d;
+$dark-grey: #757575;
+$border-grey: #ddd;
 
 //Did You Know
 $feature: #039BD3;
@@ -35,6 +40,7 @@ $aaa: #AAAAAA;
 $security-red: #E47F7F;
 $security-yellow: #FCCC65;
 $security-green: #3CC476;
+$bright-green:  #3CC476 !important; //override Security Center nested css selectors
 
 //Color Mixin
 @mixin color($name, $color) {
@@ -49,10 +55,10 @@ $security-green: #3CC476;
 @include color('dark-blue', $dark-blue);
 @include color('deep-blue', $deep-blue);
 @include color('black', $black);
-@include color('dark-grey', $dark-grey);
+@include color('grey', $light-grey);
 @include color('light-grey', $light-grey);
 @include color('mid-grey', $mid-grey);
-@include color('mid-grey-alt', $mid-grey-alt);
+@include color('dark-grey', $dark-grey);
 @include color('receive-green', $receive-green);
 @include color('security-red', $security-red);
 @include color('security-yellow', $security-yellow);
@@ -79,6 +85,6 @@ $security-green: #3CC476;
 @include bg-color('black', $black);
 @include bg-color('dark-grey', $dark-grey);
 @include bg-color('light-grey', $light-grey);
-@include bg-color('light-grey-alt', $light-grey-alt);
+@include bg-color('light-blue', $light-blue);
 @include bg-color('mid-grey', $mid-grey);
 @include bg-color('success', $success);

--- a/assets/css/utilities/_typography.scss
+++ b/assets/css/utilities/_typography.scss
@@ -12,7 +12,7 @@
 .right-align { text-align: right; }
 .left-align { text-align: left; }
 .center-align { text-align: center; }
-.lh-lg { line-height: 2; }
+.lh-lg { line-height: 1.75; }
 .shadow { text-shadow: 0 1px 1px #ccc; }
 .em-alt { text-transform: uppercase; }
 .no-select { user-select: none; }

--- a/locales/en-human.json
+++ b/locales/en-human.json
@@ -476,6 +476,7 @@
   "MOBILE_LINKED" : "Mobile Linked",
   "SCAN_QR_CODE" : "Scan your QR code:",
   "HINT_STORED" : "Hint Stored",
+  "NOT_STORED" : "Not Stored",
   "PHRASE_BACKED" : "Phrase Backed",
   "EMAIL_VERIFIED" : "Email Verified",
   "LAUNCHED" : "We've launched!",


### PR DESCRIPTION
There are a lot of ui things going on here, but I'll screenshot the most important things:

1) Change the color of our Blockchain blue to the ones our mobile apps are using (it's gonna feel darker)
2) Normalize all the Settings views to use "labels" if they have a disabled/enabled state
3) Get rid of references to Bootstrap buttons and use our own (better) button styles

A lot of this was refactoring the .scss files so that we're using variable names for colors and not hex values!

<img width="1552" alt="screen shot 2015-08-25 at 5 28 27 pm" src="https://cloud.githubusercontent.com/assets/824209/9480088/fffd2232-4b4e-11e5-8b95-ab654baadbf9.png">
<img width="728" alt="screen shot 2015-08-25 at 5 28 44 pm" src="https://cloud.githubusercontent.com/assets/824209/9480085/fff95594-4b4e-11e5-8740-f47e6583f508.png">
<img width="491" alt="screen shot 2015-08-25 at 5 28 53 pm" src="https://cloud.githubusercontent.com/assets/824209/9480086/fffbc496-4b4e-11e5-9f22-3aa8f8ff75f5.png">
<img width="395" alt="screen shot 2015-08-25 at 5 28 58 pm" src="https://cloud.githubusercontent.com/assets/824209/9480087/fffc74ea-4b4e-11e5-92df-ea3fc11ddb13.png">



