### PR TITLE
Prevent user from generating HD address after upgrade pending sync

### DIFF
--- a/app/partials/settings/addresses.jade
+++ b/app/partials/settings/addresses.jade
@@ -2,7 +2,7 @@ h5.well.headliner.hidden-xs(translate="MY_ADDRESSES_EXPLAIN_TEMP")
 
 .form-ctrl.flex-between.flex-center
   .mrl(dropdown is-open="display.account_dropdown_open")
-    button.button-primary.dropdown-toggle(dropdown-toggle type="button", data-toggle="dropdown", aria-expanded="false")
+    button.button-primary.dropdown-toggle(dropdown-toggle type="button", data-toggle="dropdown", aria-expanded="false", ng-disabled="!status.didInitializeHD")
       span.prs(translate="NEW_ADDRESS")
       span.caret
     ul.dropdown-menu(role="menu")


### PR DESCRIPTION
This solves the following (unlikely) edge case:
When the user upgrades from a legacy wallet a new BIP39 mnemonic is generated and the wallet is saved again. If this save operation fails then the next time the user logs in a different BIP 39 mnemonic is generated and the user would lose access to any funds deposited on an HD address. If the user goes to settings -> addresses and clicks New Address they would be able to send funds to themselves. 

They can't easily do this because the upgrade modal can't be dismissed, but they could manually navigate to #/settings/addresses

This fix disables the New Address button after an upgrade until the sync is complete.